### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.Calculator.json
+++ b/org.gnome.Calculator.json
@@ -17,10 +17,6 @@
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
-    "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g"
-    },
     "cleanup": ["/include", "/lib/pkgconfig",
                 "/share/pkgconfig", "/share/aclocal",
                 "/man", "/share/man", "/share/gtk-doc",


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.