### PR TITLE
GNOME runtime 41, gnome-calculator 41

### DIFF
--- a/org.gnome.Calculator.json
+++ b/org.gnome.Calculator.json
@@ -62,8 +62,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-calculator/40/gnome-calculator-40.1.tar.xz",
-                    "sha256": "7fe6c561f7b1f485ac106219772e45cc135c983bfa4278dd2d3fd83b57ff6af6"
+                    "url": "https://download.gnome.org/sources/gnome-calculator/41/gnome-calculator-41.0.tar.xz",
+                    "sha256": "a66dc04bd8587e76d67375a6aefa79553b569c9bdf78ebdc2817f1c0ade3dc99"
                 },
                 {
                     "type": "patch",

--- a/org.gnome.Calculator.json
+++ b/org.gnome.Calculator.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Calculator",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-calculator",
     "finish-args": [

--- a/patches/gnome-calculator/fix-appdata-releases.patch
+++ b/patches/gnome-calculator/fix-appdata-releases.patch
@@ -1,8 +1,26 @@
 diff --git a/data/org.gnome.Calculator.appdata.xml.in b/data/org.gnome.Calculator.appdata.xml.in
-index 2a3b4f86..18f6edcc 100644
+index e981d537..5f318c72 100644
 --- a/data/org.gnome.Calculator.appdata.xml.in
 +++ b/data/org.gnome.Calculator.appdata.xml.in
-@@ -72,7 +72,7 @@
+@@ -82,7 +82,7 @@
+         </ul>
+       </description>
+     </release>
+-    <release version="41.rc" date="2021-09-04" type="development">
++    <release version="41~rc" date="2021-09-04" type="development">
+       <description>
+         <p>Overview of changes in gnome-calculator 41.rc</p>
+         <ul>
+@@ -90,7 +90,7 @@
+         </ul>
+       </description>
+     </release>
+-    <release version="41.alpha" date="2021-07-10" type="development">
++    <release version="41~alpha" date="2021-07-10" type="development">
+       <description>
+         <p>Overview of changes in gnome-calculator 41.alpha</p>
+         <ul>
+@@ -115,7 +115,7 @@
          </ul>
        </description>
      </release>
@@ -11,7 +29,7 @@ index 2a3b4f86..18f6edcc 100644
        <description>
          <p>Overview of changes in gnome-calculator 40.rc</p>
          <ul>
-@@ -90,7 +90,7 @@
+@@ -133,7 +133,7 @@
          </ul>
        </description>
      </release>  
@@ -20,7 +38,7 @@ index 2a3b4f86..18f6edcc 100644
        <description>
          <p>Overview of changes in gnome-calculator 40.beta</p>
          <ul>
-@@ -110,7 +110,7 @@
+@@ -153,7 +153,7 @@
          </ul>
        </description>
      </release>  


### PR DESCRIPTION
Updated GNOME runtime to 41, updated gnome-calculator to 41