### PR TITLE
Update gnome-calculator-43.0.1.tar.xz to 44.0

### DIFF
--- a/org.gnome.Calculator.json
+++ b/org.gnome.Calculator.json
@@ -63,8 +63,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-calculator/43/gnome-calculator-43.0.1.tar.xz",
-                    "sha256": "02c12ded3cf5053d17537d95ec69587f4b919899d7726eceecdb4b47ffb1c90f",
+                    "url": "https://download.gnome.org/sources/gnome-calculator/44/gnome-calculator-44.0.tar.xz",
+                    "sha256": "14e763329f88309a7e152780d57361b543100e323906b34e0655fdc315b71043",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "gnome-calculator"


### PR DESCRIPTION
Continuation of https://github.com/flathub/org.gnome.Calculator/pull/27